### PR TITLE
Redesign profile README: GitHub-compatible HTML + animated SVG hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,31 @@
+<!--
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  GitHub profile README — github.com/carlomigueldy                      │
+  │  HTML here is limited to what GitHub's markup sanitizer allows:        │
+  │  no <style>, no inline style="", no <script>. All visual design lives  │
+  │  in the SVG assets (assets/banner.svg, assets/footer.svg), which are   │
+  │  theme-adaptive (light/dark) and animate on load.                      │
+  │  Swap the assets/* files anytime — paths stay the same.                │
+  └──────────────────────────────────────────────────────────────────────┘
+-->
+
 <div align="center">
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                                                             │
-│     C A R L O   M I G U E L   D Y    ·   @carlomigueldy     │
-│                                                             │
-│        senior fullstack engineer  /  web3  /  ai-native     │
-│                                                             │
-└─────────────────────────────────────────────────────────────┘
-```
+<img src="assets/banner.svg" alt="Carlo Miguel Dy — senior fullstack engineer · web3 · ai-native. Open to work, remote from the Philippines." width="100%" />
 
-**I take ambiguous product requirements and turn them into shipped production systems.**
+<br><br>
 
-`philippines · remote` — `7+ yrs eng` — `4+ yrs web3` — `daily claude code & codex`
-
-[![Portfolio](https://img.shields.io/badge/-carlomigueldy.dev-0a0a0a?style=flat-square&logo=vercel&logoColor=white)](https://carlomigueldy.dev)
-[![Email](https://img.shields.io/badge/-carlomigueldy@gmail.com-0a0a0a?style=flat-square&logo=gmail&logoColor=white)](mailto:carlomigueldy@gmail.com)
-[![LinkedIn](https://img.shields.io/badge/-linkedin-0a0a0a?style=flat-square&logo=linkedin&logoColor=white)](https://linkedin.com/in/carlomigueldy)
+<a href="https://carlomigueldy.dev"><img src="https://img.shields.io/badge/Portfolio-carlomigueldy.dev-0D1117?style=flat-square&logo=vercel&logoColor=white" alt="Portfolio" /></a>
+&nbsp;
+<a href="mailto:carlomigueldy@gmail.com"><img src="https://img.shields.io/badge/Email-carlomigueldy@gmail.com-0D1117?style=flat-square&logo=gmail&logoColor=white" alt="Email" /></a>
+&nbsp;
+<a href="https://linkedin.com/in/carlomigueldy"><img src="https://img.shields.io/badge/LinkedIn-carlomigueldy-0D1117?style=flat-square&logo=linkedin&logoColor=white" alt="LinkedIn" /></a>
+&nbsp;
+<a href="https://x.com/carlomigueldy"><img src="https://img.shields.io/badge/X-@carlomigueldy-0D1117?style=flat-square&logo=x&logoColor=white" alt="X" /></a>
 
 </div>
+
+> **I take ambiguous product requirements and turn them into shipped production systems.**
 
 ---
 
@@ -40,17 +47,48 @@ const miguel = {
 
 ### `// recent work worth talking about`
 
-**🛰 &nbsp; Rumour — Web3 social trading on Hyperliquid** — `@AltLayer`
-> Led frontend across the rumour-to-trade flow — owned the Farcaster Miniapp and LINE DappPortal shells end-to-end, the wallet-setup flow on Privy embedded wallets, the Tencent Chat messaging layer, and the perps trading UI on the Hyperliquid SDK. Ships as a PWA, Farcaster Miniapp, and LINE DappPortal Mini Dapp from a single React + Vite codebase.
+<table>
+<tr>
+<td width="50%" valign="top">
 
-**🤖 &nbsp; Autonome — no-code AI-agent deployment platform** — `@AltLayer`
-> Owned the framework-discovery gallery, new-agent deployment flow, agent metadata editor, environment-variables dialog, and the Eliza framework UI integration inside the unified AltLayer Wizard frontend. Users pick a framework, configure persona and keys, and get a chat-ready agent in ~5 minutes.
+<br>
+&nbsp;🛰&nbsp;&nbsp;<b>Rumour</b>&nbsp;&nbsp;<img src="https://img.shields.io/badge/AltLayer-F5A623?style=flat-square&labelColor=0D1117" alt="AltLayer" />
+<br><br>
+<sub><b>Web3 social trading on Hyperliquid.</b> Led frontend across the rumour-to-trade flow — owned the Farcaster Miniapp and LINE DappPortal shells end-to-end, the wallet-setup flow on Privy embedded wallets, the Tencent Chat messaging layer, and the perps trading UI on the Hyperliquid SDK. Ships as a PWA, Farcaster Miniapp, and LINE Mini Dapp from a single React&nbsp;+&nbsp;Vite codebase.</sub>
+<br><br>
 
-**🎯 &nbsp; Limitless Labs — prediction markets on Base** — `@Limitless Labs`
-> Architected the NestJS / Fastify / PostgreSQL backend using domain-driven design and automated the full market lifecycle into an orchestration system that let operators create 10+ markets a day. Collapsed the manually-assembled market-creation flow into a single operator action behind an internal form, REST API, and Gnosis Safe SDK approval link.
+</td>
+<td width="50%" valign="top">
 
-**🌐 &nbsp; Atlantis World — Web3 social metaverse + $1M NFT sale** — `@Atlantis World`
-> Promoted from blockchain engineer to lead blockchain engineer. Owned 11 of 16 DeFi/Web3 protocol integrations end-to-end (Yearn, 1inch, Balancer, Aave, Perpetual Protocol, Moola, Lens, Filecoin, Snapshot, NFT.Storage, POAP) and ran the live shift for the community NFT sale that raised ~$1M ETH.
+<br>
+&nbsp;🤖&nbsp;&nbsp;<b>Autonome</b>&nbsp;&nbsp;<img src="https://img.shields.io/badge/AltLayer-F5A623?style=flat-square&labelColor=0D1117" alt="AltLayer" />
+<br><br>
+<sub><b>No-code AI-agent deployment platform.</b> Owned the framework-discovery gallery, new-agent deployment flow, agent metadata editor, environment-variables dialog, and the Eliza framework UI integration inside the unified AltLayer Wizard frontend. Users pick a framework, configure persona and keys, and get a chat-ready agent in ~5 minutes.</sub>
+<br><br>
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+<br>
+&nbsp;🎯&nbsp;&nbsp;<b>Limitless Labs</b>&nbsp;&nbsp;<img src="https://img.shields.io/badge/Limitless%20Labs-F5A623?style=flat-square&labelColor=0D1117" alt="Limitless Labs" />
+<br><br>
+<sub><b>Prediction markets on Base.</b> Architected the NestJS / Fastify / PostgreSQL backend using domain-driven design and automated the full market lifecycle into an orchestration system that let operators create 10+ markets a day. Collapsed the manually-assembled market-creation flow into a single operator action behind an internal form, REST API, and Gnosis Safe SDK approval link.</sub>
+<br><br>
+
+</td>
+<td width="50%" valign="top">
+
+<br>
+&nbsp;🌐&nbsp;&nbsp;<b>Atlantis World</b>&nbsp;&nbsp;<img src="https://img.shields.io/badge/Atlantis%20World-F5A623?style=flat-square&labelColor=0D1117" alt="Atlantis World" />
+<br><br>
+<sub><b>Web3 social metaverse + $1M NFT sale.</b> Promoted from blockchain engineer to lead blockchain engineer. Owned 11 of 16 DeFi/Web3 protocol integrations end-to-end (Yearn, 1inch, Balancer, Aave, Perpetual Protocol, Moola, Lens, Filecoin, Snapshot, NFT.Storage, POAP) and ran the live shift for the community NFT sale that raised ~$1M ETH.</sub>
+<br><br>
+
+</td>
+</tr>
+</table>
 
 ---
 
@@ -82,6 +120,7 @@ I use Claude Code, Codex, Multica AI and MCP-based workflows **every day** — n
 I'm actively looking to **join a team** — senior software, senior fullstack, senior frontend, or senior Web3 / blockchain engineer roles. Best fit: teams building in Web3, AI-native software, fintech, developer tools, marketplaces, or product-led SaaS.
 
 The shape of the work I do best:
+
 - a small team where one engineer can own a meaningful surface area
 - ambiguous problems that need a working answer, not a perfect one
 - a culture that respects both shipping speed *and* test coverage
@@ -92,6 +131,6 @@ If that sounds like your team — [carlomigueldy.dev](https://carlomigueldy.dev)
 
 <div align="center">
 
-<sub>`built end-to-end · tested before shipped · shipped before perfected`</sub>
+<img src="assets/footer.svg" alt="built end-to-end · tested before shipped · shipped before perfected" width="100%" />
 
 </div>

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,0 +1,150 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 300" role="img" aria-label="Carlo Miguel Dy — senior fullstack engineer · web3 · ai-native. Open to work, remote from the Philippines.">
+  <title>Carlo Miguel Dy — senior fullstack engineer · web3 · ai-native</title>
+
+  <defs>
+    <!-- film grain -->
+    <filter id="grain" x="-5%" y="-5%" width="110%" height="110%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.82" numOctaves="2" stitchTiles="stitch" result="n"/>
+      <feColorMatrix in="n" type="saturate" values="0"/>
+    </filter>
+
+    <!-- soft outer shadow for the window -->
+    <filter id="lift" x="-20%" y="-20%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="14" stdDeviation="22" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+
+    <!-- accent glow used by the status dots -->
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="3" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <!-- scanline texture -->
+    <pattern id="scan" width="3" height="3" patternUnits="userSpaceOnUse">
+      <rect width="3" height="1" class="scanline"/>
+    </pattern>
+
+    <clipPath id="screen"><rect x="20" y="20" width="840" height="260" rx="16"/></clipPath>
+
+    <style>
+      svg{
+        --bg:#f3efe6; --panel:#fbf9f4; --frame:#e7e1d4; --chrome:#efeadf;
+        --ink:#1b1a16; --dim:#8c8676; --faint:#b6b0a0;
+        --accent:#c2410c; --accent2:#15803d; --wire:#1b1a16;
+      }
+      @media (prefers-color-scheme: dark){
+        svg{
+          --bg:#070a0f; --panel:#0c1016; --frame:#1b2230; --chrome:#11161f;
+          --ink:#ecebe6; --dim:#6b7686; --faint:#3a4456;
+          --accent:#f5a623; --accent2:#3fb950; --wire:#e7e6e1;
+        }
+      }
+
+      .bg{ fill:var(--bg); }
+      .panel{ fill:var(--panel); }
+      .frame{ fill:none; stroke:var(--frame); stroke-width:1.25; }
+      .chrome{ fill:var(--chrome); }
+      .scanline{ fill:var(--wire); opacity:.05; }
+      .grain{ opacity:.06; }
+
+      .mono{ font-family:'SF Mono','JetBrains Mono','Fira Code','Cascadia Code',ui-monospace,Menlo,Consolas,monospace; }
+      .prompt{ fill:var(--dim); }
+      .cmd{ fill:var(--accent); }
+      .arrow{ fill:var(--accent2); }
+      .ink{ fill:var(--ink); }
+      .dim{ fill:var(--dim); }
+      .title{ fill:var(--dim); letter-spacing:.5px; }
+
+      .name{ fill:var(--ink); font-weight:700; letter-spacing:5px; }
+      .role{ fill:var(--dim); letter-spacing:3px; }
+
+      .chip{ fill:none; stroke:var(--frame); stroke-width:1.25; }
+      .chiptext{ fill:var(--dim); letter-spacing:.5px; }
+
+      /* ---- motion: reveal once, then settle ---- */
+      .row{ opacity:0; animation:rise .55s cubic-bezier(.2,.7,.2,1) forwards; }
+      .r1{ animation-delay:.15s; } .r2{ animation-delay:.5s; }
+      .r3{ animation-delay:.85s; } .r4{ animation-delay:1.15s; } .r5{ animation-delay:1.5s; }
+
+      @keyframes rise{ from{opacity:0; transform:translateY(9px);} to{opacity:1; transform:translateY(0);} }
+      @keyframes blink{ 0%,48%{opacity:1;} 49%,100%{opacity:0;} }
+      @keyframes pulse{ 0%,100%{opacity:1;} 50%{opacity:.28;} }
+      @keyframes sweep{ 0%{transform:translateY(-40px);} 100%{transform:translateY(300px);} }
+
+      .cursor{ fill:var(--accent); animation:blink 1.05s steps(1) infinite; animation-delay:2s; }
+      .dot1{ animation:pulse 2.4s ease-in-out infinite; }
+      .dot2{ animation:pulse 2.4s ease-in-out .4s infinite; }
+      .dot3{ animation:pulse 2.4s ease-in-out .8s infinite; }
+      .sheen{ opacity:.04; fill:var(--wire); animation:sweep 7s linear infinite; }
+    </style>
+  </defs>
+
+  <!-- backdrop -->
+  <rect x="0" y="0" width="880" height="300" class="bg"/>
+
+  <!-- terminal window -->
+  <g filter="url(#lift)">
+    <rect x="20" y="20" width="840" height="260" rx="16" class="panel"/>
+    <rect x="20" y="20" width="840" height="260" rx="16" class="frame"/>
+  </g>
+
+  <!-- screen-clipped texture + content -->
+  <g clip-path="url(#screen)">
+    <rect x="20" y="20" width="840" height="260" fill="url(#scan)"/>
+    <rect x="20" y="20" width="840" height="260" class="grain" filter="url(#grain)"/>
+    <rect x="0" y="0" width="880" height="34" class="sheen"/>
+
+    <!-- title bar -->
+    <rect x="20" y="20" width="840" height="46" class="chrome"/>
+    <line x1="20" y1="66" x2="860" y2="66" stroke="var(--frame)" stroke-width="1.25"/>
+    <circle cx="48"  cy="43" r="6" fill="#ff5f56"/>
+    <circle cx="70"  cy="43" r="6" fill="#ffbd2e"/>
+    <circle cx="92"  cy="43" r="6" fill="#27c93f"/>
+    <text x="440" y="48" text-anchor="middle" class="mono title" font-size="13">carlomigueldy@dev — ~/portfolio — zsh</text>
+
+    <!-- line 1: whoami -->
+    <g class="row r1">
+      <text x="48" y="108" class="mono" font-size="15">
+        <tspan class="prompt">carlomigueldy</tspan><tspan class="dim"> ~ </tspan><tspan class="prompt">%</tspan><tspan class="cmd">  ./whoami</tspan>
+      </text>
+    </g>
+
+    <!-- line 2: the name (hero) -->
+    <g class="row r2">
+      <text x="48" y="162" class="mono name" font-size="42">CARLO MIGUEL DY</text>
+    </g>
+
+    <!-- line 3: role -->
+    <g class="row r3">
+      <text x="50" y="194" class="mono role" font-size="15">senior fullstack engineer<tspan class="ink"> · </tspan>web3<tspan class="ink"> · </tspan>ai-native</text>
+    </g>
+
+    <!-- line 4: status command -->
+    <g class="row r4">
+      <text x="48" y="236" class="mono" font-size="15">
+        <tspan class="prompt">carlomigueldy</tspan><tspan class="dim"> ~ </tspan><tspan class="prompt">%</tspan><tspan class="cmd">  ./status --now</tspan>
+      </text>
+    </g>
+
+    <!-- line 5: status chips -->
+    <g class="row r5">
+      <!-- open to work -->
+      <rect x="48" y="250" width="152" height="26" rx="13" class="chip"/>
+      <circle cx="66" cy="263" r="4" fill="var(--accent2)" class="dot1" filter="url(#glow)"/>
+      <text x="78" y="267" class="mono chiptext" font-size="12">open to work</text>
+
+      <!-- remote -->
+      <rect x="210" y="250" width="188" height="26" rx="13" class="chip"/>
+      <circle cx="228" cy="263" r="4" fill="var(--accent)" class="dot2" filter="url(#glow)"/>
+      <text x="240" y="267" class="mono chiptext" font-size="12">remote · philippines</text>
+
+      <!-- experience -->
+      <rect x="408" y="250" width="190" height="26" rx="13" class="chip"/>
+      <circle cx="426" cy="263" r="4" fill="var(--accent)" class="dot3" filter="url(#glow)"/>
+      <text x="438" y="267" class="mono chiptext" font-size="12">7+ yrs · 4+ yrs web3</text>
+
+      <!-- blinking cursor -->
+      <rect x="612" y="252" width="11" height="22" class="cursor"/>
+    </g>
+  </g>
+</svg>

--- a/assets/footer.svg
+++ b/assets/footer.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 52" role="img" aria-label="built end-to-end · tested before shipped · shipped before perfected">
+  <title>built end-to-end · tested before shipped · shipped before perfected</title>
+  <defs>
+    <clipPath id="bar"><rect x="0" y="6" width="880" height="40" rx="10"/></clipPath>
+    <style>
+      svg{
+        --panel:#fbf9f4; --frame:#e7e1d4; --ink:#1b1a16; --dim:#8c8676;
+        --accent:#c2410c; --accent2:#15803d;
+      }
+      @media (prefers-color-scheme: dark){
+        svg{ --panel:#0c1016; --frame:#1b2230; --ink:#ecebe6; --dim:#6b7686;
+             --accent:#f5a623; --accent2:#3fb950; }
+      }
+      .panel{ fill:var(--panel); }
+      .frame{ fill:none; stroke:var(--frame); stroke-width:1.25; }
+      .mono{ font-family:'SF Mono','JetBrains Mono','Fira Code',ui-monospace,Menlo,Consolas,monospace; }
+      .dim{ fill:var(--dim); letter-spacing:.4px; }
+      .ok{ fill:var(--accent2); }
+      .ac{ fill:var(--accent); }
+      @keyframes pulse{ 0%,100%{opacity:1;} 50%{opacity:.3;} }
+      @keyframes shimmer{ 0%{transform:translateX(-220px);} 100%{transform:translateX(900px);} }
+      .live{ animation:pulse 2.2s ease-in-out infinite; }
+      .shim{ fill:var(--accent); opacity:.05; animation:shimmer 6s linear infinite; }
+    </style>
+    <linearGradient id="fade" x1="0" x2="1">
+      <stop offset="0" stop-color="white" stop-opacity="0"/>
+      <stop offset="0.5" stop-color="white" stop-opacity="1"/>
+      <stop offset="1" stop-color="white" stop-opacity="0"/>
+    </linearGradient>
+    <mask id="fademask"><rect x="0" y="6" width="880" height="40" fill="url(#fade)"/></mask>
+  </defs>
+
+  <rect x="0" y="6" width="880" height="40" rx="10" class="panel"/>
+  <g clip-path="url(#bar)">
+    <rect x="0" y="6" width="180" height="40" class="shim"/>
+  </g>
+  <rect x="0" y="6" width="880" height="40" rx="10" class="frame"/>
+
+  <circle cx="28" cy="26" r="4.5" class="ok live"/>
+  <text x="42" y="30" class="mono dim" font-size="12.5">online<tspan class="ac">  ·  </tspan>~/carlomigueldy</text>
+
+  <text x="838" y="30" text-anchor="end" class="mono dim" font-size="12.5">
+    <tspan class="ok">✓</tspan> built end-to-end<tspan class="ac">  ·  </tspan><tspan class="ok">✓</tspan> tested before shipped<tspan class="ac">  ·  </tspan><tspan class="ok">✓</tspan> shipped before perfected
+  </text>
+</svg>


### PR DESCRIPTION
Reworks the profile README (`github.com/carlomigueldy`) into a **GitHub-profile-compatible HTML implementation**, with the visual design carried by theme-adaptive, animated SVG assets.

## What changed

- **`assets/banner.svg`** — animated terminal "build-log" hero. Types out the identity (`./whoami` → `CARLO MIGUEL DY` → role → `./status --now` → live status chips with a blinking cursor). Adapts to light/dark via `prefers-color-scheme`, animates on load with in-SVG CSS keyframes that run **once and settle** (no looping distraction), and uses `feTurbulence` grain + scanlines for texture.
- **`assets/footer.svg`** — slim status-bar bookend (`online · ~/carlomigueldy … ✓ built · ✓ tested · ✓ shipped`), same adaptive theming.
- **`README.md`** — reimplemented with **GitHub-safe HTML only**: centered hero + shields badges, a 2×2 HTML `<table>` of project cards, and the SVG footer. The TypeScript identity block, the stack spec-sheet, and all prose/voice are preserved.

## Design direction

An **amber "build-log" terminal** — it elevates the existing terminal aesthetic but deliberately dodges the overused green-terminal cliché. Warm paper + burnt-orange in light, near-black + signal-amber in dark.

## Why it's built this way (GitHub's constraints)

GitHub's README markup sanitizer strips `<style>`, inline `style="…"`, `<script>`, and CSS classes — so none of the design can live in the README HTML. Instead:
- All visuals live inside the **SVG assets**, which GitHub renders under a sandbox: internal `<style>` + `@keyframes` **work** (this is what animates), but external fonts and embedded raster images are **blocked** — so the assets use only a **system-monospace** stack and vector/`feTurbulence` texture.
- Project cards use **HTML inside table cells** (`<img>`, `<b>`, `<br>`, `<sub>`), because markdown (`**bold**`, `![badge]`) renders inconsistently inside `<table>`.

## Verification

Rendered the pushed branch's `README.md` on GitHub's actual blob view (real sanitizer + camo proxy + SVG sandbox) and screenshotted with `prefers-color-scheme` emulated **dark and light**:
- Banner + footer adapt correctly per theme; animations play through camo.
- Badges, the 2×2 project table, and amber company pills all render — nothing stripped, no broken images.

## Notes for the owner

The `assets/*.svg` files are placeholders you can swap anytime — **paths stay stable** (`assets/banner.svg`, `assets/footer.svg`), so dropping in replacements needs no README edits. The profile only re-renders after merge to `main`, but this branch's `blob` view renders identically for preview.